### PR TITLE
refactor: improve code readability and consistency

### DIFF
--- a/packages/sitepackage/Classes/Backend/Controller/EventNotificationController.php
+++ b/packages/sitepackage/Classes/Backend/Controller/EventNotificationController.php
@@ -90,10 +90,10 @@ class EventNotificationController extends ActionController
         $fluidEmail = new FluidEmail();
         $fluidEmail
             ->bcc(...$emailAddresses)
-            ->from(new Address('hallo@mens-circle.de', 'Men\'s Circle Website'))
+            ->from(new Address('hallo@mens-circle.de', "Men's Circle Website"))
             ->subject($eventNotification->subject)
             ->format(FluidEmail::FORMAT_BOTH)
-            ->to(new Address('hallo@mens-circle.de', 'Men\'s Circle Website'))
+            ->to(new Address('hallo@mens-circle.de', "Men's Circle Website"))
             ->setTemplate('EventNotification')
             ->assign('subject', $eventNotification->subject)
             ->assign('message', $eventNotification->message)

--- a/packages/sitepackage/Classes/Backend/Controller/NewsletterController.php
+++ b/packages/sitepackage/Classes/Backend/Controller/NewsletterController.php
@@ -57,6 +57,7 @@ class NewsletterController extends ActionController
         $moduleTemplate = $this->initializeModuleTemplate($this->request);
         $this->pageRenderer->loadJavaScriptModule('@mens-circle/sitepackage/bootstrap.js');
         $this->pageRenderer->addCssFile('EXT:sitepackage/Resources/Public/Backend/Styles/bootstrap.css');
+
         $moduleTemplate->setTitle('Newsletter');
 
         $subscriptions = $this->subscriptionRepository->findBy([
@@ -99,7 +100,7 @@ class NewsletterController extends ActionController
         foreach ($emailAddresses as $emailAddress) {
             $fluidEmail = new FluidEmail();
             $fluidEmail
-                ->from(new Address('hallo@mens-circle.de', 'Men\'s Circle Website'))
+                ->from(new Address('hallo@mens-circle.de', "Men's Circle Website"))
                 ->subject($newsletter->subject)
                 ->format(FluidEmail::FORMAT_BOTH)
                 ->to($emailAddress)

--- a/packages/sitepackage/Classes/Command/SyncNewsletterSubscriptionCommand.php
+++ b/packages/sitepackage/Classes/Command/SyncNewsletterSubscriptionCommand.php
@@ -15,6 +15,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class SyncNewsletterSubscriptionCommand extends Command
 {
     protected const string SOURCE_TABLE = 'fe_users';
+
     protected const string TARGET_TABLE = 'tx_sitepackage_domain_model_subscription';
 
     public function __construct(protected readonly ConnectionPool $connectionPool)
@@ -35,8 +36,8 @@ final class SyncNewsletterSubscriptionCommand extends Command
         try {
             $feusers = $this->getAllFeUsers();
             $subscriptions = $this->getAllSubscriptions();
-        } catch (Exception $e) {
-            $symfonyStyle->error('Failed to read from database: '.$e->getMessage());
+        } catch (Exception $exception) {
+            $symfonyStyle->error('Failed to read from database: '.$exception->getMessage());
 
             return Command::FAILURE;
         }
@@ -53,12 +54,15 @@ final class SyncNewsletterSubscriptionCommand extends Command
             if ($emailLower === '') {
                 continue;
             }
+
             if (filter_var($emailLower, \FILTER_VALIDATE_EMAIL) === false) {
                 continue;
             }
+
             if (\in_array($emailLower, $subscriptionEmailsLower, true)) {
                 continue; // already subscribed
             }
+
             if (!isset($toSyncByEmail[$emailLower])) {
                 $toSyncByEmail[$emailLower] = $user;
             }
@@ -106,11 +110,12 @@ final class SyncNewsletterSubscriptionCommand extends Command
 
                 $symfonyStyle->progressAdvance();
             }
+
             $connection->commit();
-        } catch (Exception $e) {
+        } catch (Exception $exception) {
             $connection->rollBack();
             $symfonyStyle->progressFinish();
-            $symfonyStyle->error('Failed to sync subscriptions: '.$e->getMessage());
+            $symfonyStyle->error('Failed to sync subscriptions: '.$exception->getMessage());
 
             return Command::FAILURE;
         }

--- a/packages/sitepackage/Classes/Controller/SubscriptionController.php
+++ b/packages/sitepackage/Classes/Controller/SubscriptionController.php
@@ -65,6 +65,7 @@ class SubscriptionController extends ActionController
 
         $subscription->doubleOptInToken = $this->tokenService->generateToken();
         $subscription->optInDate = new \DateTime();
+
         $this->subscriptionRepository->add($subscription);
 
         $this->emailService->sendMail(
@@ -96,6 +97,7 @@ class SubscriptionController extends ActionController
         if ($email === '') {
             return $this->htmlResponse();
         }
+
         $subscription = $this->subscriptionRepository->findOneBy([
             'email' => $email,
         ]);

--- a/packages/sitepackage/Classes/Domain/Model/Event.php
+++ b/packages/sitepackage/Classes/Domain/Model/Event.php
@@ -162,7 +162,7 @@ class Event extends AbstractEntity
 
     public function getFullAddress(): string
     {
-        return "{$this->location->address}, {$this->location->zip} {$this->location->city}, Deutschland";
+        return \sprintf('%s, %s %s, Deutschland', $this->location->address, $this->location->zip, $this->location->city);
     }
 
     public function setParticipants(ObjectStorage $objectStorage): void

--- a/packages/sitepackage/Classes/Middleware/EventApiMiddleware.php
+++ b/packages/sitepackage/Classes/Middleware/EventApiMiddleware.php
@@ -25,9 +25,11 @@ use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
 readonly class EventApiMiddleware implements MiddlewareInterface
 {
     public const string BASE_PATH = '/api/event/';
+
     public const string PATH_ICAL = '/ical';
 
     private const string ORGANIZER_EMAIL = 'hallo@mens-circle.de';
+
     private const string ORGANIZER_NAME = 'Markus Sommer';
 
     public function __construct(
@@ -98,6 +100,7 @@ readonly class EventApiMiddleware implements MiddlewareInterface
             } elseif (str_contains($callUrl, 'teams.microsoft.com')) {
                 $calendarEvent->microsoftTeams($callUrl);
             }
+
             // Also add as attachment for broader client support
             $calendarEvent->attachment($callUrl, 'text/uri-list');
         } else {

--- a/packages/sitepackage/Classes/Service/EmailService.php
+++ b/packages/sitepackage/Classes/Service/EmailService.php
@@ -28,7 +28,7 @@ readonly class EmailService
     ): void {
         $fluidEmail = new FluidEmail()
             ->to($toEmail)
-            ->from(new Address('hallo@mens-circle.de', 'Men\'s Circle Website'))
+            ->from(new Address('hallo@mens-circle.de', "Men's Circle Website"))
             ->subject($subject)
             ->setRequest($serverRequest)
             ->format(FluidEmail::FORMAT_BOTH)
@@ -38,8 +38,8 @@ readonly class EmailService
 
         try {
             $this->mailer->send($fluidEmail);
-        } catch (TransportExceptionInterface $e) {
-            $this->logger->error('Failed to send Double Opt-In email: '.$e->getMessage());
+        } catch (TransportExceptionInterface $transportException) {
+            $this->logger->error('Failed to send Double Opt-In email: '.$transportException->getMessage());
         }
     }
 }

--- a/packages/sitepackage/Classes/Service/EventCalendarService.php
+++ b/packages/sitepackage/Classes/Service/EventCalendarService.php
@@ -51,8 +51,11 @@ final class EventCalendarService implements SingletonInterface
 
     // Centralized alarm configuration
     private const string PRIMARY_ALARM_TEXT = 'Event reminder';
+
     private const string SECONDARY_ALARM_TEXT = 'Event starting in 1 hour';
+
     private const string PRIMARY_ALARM_OFFSET = '-15 minutes';
+
     private const string SECONDARY_ALARM_OFFSET = '-1 hour';
 
     private ?array $cachedEvents = null;
@@ -73,7 +76,7 @@ final class EventCalendarService implements SingletonInterface
             self::FORMAT_JSON => $this->generateJsonFeed($events),
             self::FORMAT_ICS => $this->generateIcsFeed($events),
             self::FORMAT_JCAL => $this->generateJcalFeed($events),
-            default => throw new \InvalidArgumentException("Unsupported format: {$format}", 1278997658),
+            default => throw new \InvalidArgumentException('Unsupported format: '.$format, 1278997658),
         };
     }
 
@@ -121,13 +124,7 @@ final class EventCalendarService implements SingletonInterface
                 ->value,
         ], $events);
 
-        usort($data, static function (array $a, array $b): int {
-            // Sort by startDate then uid for stable ordering
-            $left = [$a['startDate'], $a['uid']];
-            $right = [$b['startDate'], $b['uid']];
-
-            return $left <=> $right;
-        });
+        usort($data, static fn (array $a, array $b): int => [$a['startDate'], $a['uid']] <=> [$b['startDate'], $b['uid']]);
 
         return $data;
     }
@@ -403,7 +400,7 @@ final class EventCalendarService implements SingletonInterface
         if ($event->isOnline()) {
             $url = trim($event->callUrl);
 
-            return $url !== '' && $url !== '0' ? "Online Event\\n{$url}" : 'Online Event';
+            return $url !== '' && $url !== '0' ? 'Online Event\n'.$url : 'Online Event';
         }
 
         return $this->sanitizeText($event->getFullAddress());

--- a/packages/sitepackage/Classes/Service/FrontendUserService.php
+++ b/packages/sitepackage/Classes/Service/FrontendUserService.php
@@ -44,6 +44,7 @@ readonly class FrontendUserService
         $frontendUser->setFirstName($data->firstName);
         $frontendUser->setLastName($data->lastName);
         $frontendUser->setUsername($data->email);
+
         $randomPassword = Uuid::v4()->toRfc4122();
         $passwordHash = $this->passwordHashFactory->getDefaultHashInstance('FE');
         $frontendUser->setPassword($passwordHash->getHashedPassword($randomPassword));

--- a/packages/sitepackage/Classes/Service/TokenService.php
+++ b/packages/sitepackage/Classes/Service/TokenService.php
@@ -33,7 +33,7 @@ readonly class TokenService
 
         $builder = $this->configuration->builder()
             ->issuedAt($now)
-            ->expiresAt($now->modify("+{$validForSeconds} seconds"))
+            ->expiresAt($now->modify(\sprintf('+%d seconds', $validForSeconds)))
         ;
 
         foreach ($claims as $key => $value) {

--- a/packages/sitepackage/Classes/Service/UniversalSecureTokenService.php
+++ b/packages/sitepackage/Classes/Service/UniversalSecureTokenService.php
@@ -49,6 +49,7 @@ readonly class UniversalSecureTokenService
         if ($plaintext === false) {
             throw new \RuntimeException('Die Entschlüsselung ist fehlgeschlagen – ungültige Authentifizierung.', 3859513393);
         }
+
         $result = json_decode($plaintext, true, 512, \JSON_THROW_ON_ERROR);
         if (!\is_array($result)) {
             throw new \RuntimeException('Entschlüsseltes Token hat ein unerwartetes Format.', 9807070022);

--- a/packages/sitepackage/Classes/Upgrades/ContentBlocksAboutUpgradeWizard.php
+++ b/packages/sitepackage/Classes/Upgrades/ContentBlocksAboutUpgradeWizard.php
@@ -13,7 +13,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ContentBlocksAboutUpgradeWizard implements UpgradeWizardInterface
 {
     private const string TABLE = 'tt_content';
+
     private const string OLD_TYPE = 'menscircle_about';
+
     private const string NEW_TYPE = 'sitepackage_about';
 
     public function __construct(

--- a/packages/sitepackage/Classes/Upgrades/ContentBlocksFaqUpgradeWizard.php
+++ b/packages/sitepackage/Classes/Upgrades/ContentBlocksFaqUpgradeWizard.php
@@ -13,7 +13,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ContentBlocksFaqUpgradeWizard implements UpgradeWizardInterface
 {
     private const string TABLE = 'tt_content';
+
     private const string OLD_TYPE = 'menscircle_faq';
+
     private const string NEW_TYPE = 'sitepackage_faq';
 
     public function __construct(

--- a/packages/sitepackage/Classes/Upgrades/ContentBlocksFeatureUpgradeWizard.php
+++ b/packages/sitepackage/Classes/Upgrades/ContentBlocksFeatureUpgradeWizard.php
@@ -13,7 +13,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ContentBlocksFeatureUpgradeWizard implements UpgradeWizardInterface
 {
     private const string TABLE = 'tt_content';
+
     private const string OLD_TYPE = 'menscircle_feature';
+
     private const string NEW_TYPE = 'sitepackage_feature';
 
     public function __construct(

--- a/packages/sitepackage/Classes/Upgrades/ContentBlocksHeaderUpgradeWizard.php
+++ b/packages/sitepackage/Classes/Upgrades/ContentBlocksHeaderUpgradeWizard.php
@@ -13,7 +13,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ContentBlocksHeaderUpgradeWizard implements UpgradeWizardInterface
 {
     private const string TABLE = 'tt_content';
+
     private const string OLD_TYPE = 'menscircle_header';
+
     private const string NEW_TYPE = 'sitepackage_header';
 
     public function __construct(

--- a/packages/sitepackage/Classes/Upgrades/ContentBlocksHeroUpgradeWizard.php
+++ b/packages/sitepackage/Classes/Upgrades/ContentBlocksHeroUpgradeWizard.php
@@ -13,7 +13,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ContentBlocksHeroUpgradeWizard implements UpgradeWizardInterface
 {
     private const string TABLE = 'tt_content';
+
     private const string OLD_TYPE = 'menscircle_hero';
+
     private const string NEW_TYPE = 'sitepackage_hero';
 
     public function __construct(

--- a/packages/sitepackage/Classes/Upgrades/ContentBlocksNewsletterUpgradeWizard.php
+++ b/packages/sitepackage/Classes/Upgrades/ContentBlocksNewsletterUpgradeWizard.php
@@ -13,7 +13,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ContentBlocksNewsletterUpgradeWizard implements UpgradeWizardInterface
 {
     private const string TABLE = 'tt_content';
+
     private const string OLD_TYPE = 'menscircle_newsletter';
+
     private const string NEW_TYPE = 'sitepackage_newsletter';
 
     public function __construct(

--- a/packages/sitepackage/Classes/Upgrades/ContentBlocksTextUpgradeWizard.php
+++ b/packages/sitepackage/Classes/Upgrades/ContentBlocksTextUpgradeWizard.php
@@ -13,7 +13,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ContentBlocksTextUpgradeWizard implements UpgradeWizardInterface
 {
     private const string TABLE = 'tt_content';
+
     private const string OLD_TYPE = 'menscircle_text';
+
     private const string NEW_TYPE = 'sitepackage_text';
 
     public function __construct(

--- a/packages/sitepackage/Classes/ViewHelpers/ClassViewHelper.php
+++ b/packages/sitepackage/Classes/ViewHelpers/ClassViewHelper.php
@@ -93,6 +93,7 @@ final class ClassViewHelper extends AbstractViewHelper
         if ($value === '' || $value === null) {
             return;
         }
+
         foreach (explode(' ', $value) as $class) {
             if ($class !== '') {
                 $classes[$class] = true;
@@ -111,8 +112,10 @@ final class ClassViewHelper extends AbstractViewHelper
                 if ($item) {
                     $classes[$key] = true;
                 }
+
                 continue;
             }
+
             // nested value, recurse
             self::processValue($item, $classes);
         }

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
     ->withPhpSets(php84: true)
     ->withCodeQualityLevel(75)
     ->withAttributesSets(all: true)
+    ->withCodingStyleLevel(100)
     ->withParallel()
     ->withSets([
         SetList::EARLY_RETURN,


### PR DESCRIPTION
Refactored multiple classes to improve code readability and consistency
- Updated string quoting from single to double quotes for consistency
- Improved variable naming for better clarity (e.g.,  to )
- Enhanced type checking with instanceof for better type safety
- Fixed spacing and formatting issues across multiple files
- Renamed .php-cs-fixer.dist.php to .php-cs-fixer.php