### PR TITLE
feat: filter out PHP deprecation warnings from Sentry logs

### DIFF
--- a/packages/sitepackage/Classes/Error/SentryService.php
+++ b/packages/sitepackage/Classes/Error/SentryService.php
@@ -148,6 +148,11 @@ final class SentryService implements SingletonInterface
             }
         }
 
+        // Filter out PHP deprecations
+        if (self::isDeprecation($exception)) {
+            return null;
+        }
+
         $eventId = null;
 
         withScope(static function (Scope $scope) use ($exception, &$eventId): void {
@@ -457,7 +462,28 @@ final class SentryService implements SingletonInterface
             }
         }
 
+        // Filter out PHP deprecations
+        if (self::isDeprecation($exception)) {
+            return null;
+        }
+
         return $event;
+    }
+
+    /**
+     * Check if an exception is a PHP deprecation warning.
+     *
+     * Deprecations are ErrorException instances with severity E_DEPRECATED or E_USER_DEPRECATED.
+     */
+    private static function isDeprecation(\Throwable $exception): bool
+    {
+        if (!$exception instanceof \ErrorException) {
+            return false;
+        }
+
+        $severity = $exception->getSeverity();
+
+        return $severity === \E_DEPRECATED || $severity === \E_USER_DEPRECATED;
     }
 
     private static function beforeSendTransaction(Event $event, ?EventHint $hint): ?Event


### PR DESCRIPTION
Add deprecation filtering to SentryService to prevent E_DEPRECATED and E_USER_DEPRECATED ErrorException instances from being logged to Sentry.

Changes:
- Add isDeprecation() helper method to detect deprecation errors
- Filter deprecations in captureException() method
- Filter deprecations in beforeSend() callback as safety net

This prevents noise in Sentry from PHP deprecation warnings while still capturing real errors and exceptions.