### PR TITLE
fix: restore dark mode styles lost during CSS reorganization

### DIFF
--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/about.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/about.css
@@ -1,6 +1,6 @@
 .c-about {
-    background-color: var(--bg-color--light);
-    color: var(--font-color);
+    background-color: var(--section-bg-alt);
+    color: var(--color-text);
     max-inline-size: 100vi;
     overflow: hidden;
 
@@ -26,7 +26,7 @@
 }
 
 .c-about__header {
-    color: var(--font-color);
+    color: var(--color-text);
     font-size: 2.25rem;
     font-weight: 700;
     letter-spacing: -0.025em;
@@ -39,12 +39,12 @@
 }
 
 .c-about__subheader {
-    color: var(--color--primary);
+    color: var(--color-primary);
     display: block;
 }
 
 .c-about__body {
-    color: var(--font-color);
+    color: var(--color-text);
     max-inline-size: none;
 
     @media (width >= 1024px) {

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/footer.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/footer.css
@@ -3,14 +3,10 @@
    ============================================ */
 
 .footer {
-    background: var(--color-earth);
+    background: light-dark(#4a4238, var(--color-bg-dark));
+    border-block-start: light-dark(none, 1px solid var(--card-border));
     color: var(--color-white);
     padding: var(--space-xl) var(--container-padding) var(--space-md);
-}
-
-[data-theme='dark'] .footer {
-    background: var(--color-bg-dark);
-    border-block-start: 1px solid var(--card-border);
 }
 
 .footer__content {

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/header.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/header.css
@@ -1,5 +1,5 @@
 .c-header {
-    color: var(--font-color);
+    color: var(--color-text);
     font-weight: 700;
     letter-spacing: -0.025em;
     line-height: 1;

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/hero.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/hero.css
@@ -218,7 +218,7 @@
     }
 
     .hero__image-wrapper::before {
-        background: linear-gradient(180deg, var(--hero-gradient-start) 0%, rgb(245 241 235 / 30%) 15%, transparent 35%);
+        background: linear-gradient(180deg, var(--hero-gradient-start) 0%, light-dark(rgb(245 241 235 / 30%), rgb(26 20 16 / 30%)) 15%, transparent 35%);
     }
 }
 

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/journey.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/journey.css
@@ -3,18 +3,13 @@
    ============================================ */
 
 .journey {
-    background: linear-gradient(135deg, var(--color-earth) 0%, var(--color-forest-dark) 100%);
+    background: light-dark(linear-gradient(135deg, #4a4238 0%, var(--color-forest-dark) 100%), linear-gradient(135deg, var(--color-bg-dark) 0%, #0f1410 100%));
+    border-block-end: light-dark(none, 1px solid var(--card-border));
+    border-block-start: light-dark(none, 1px solid var(--card-border));
     color: var(--color-white);
     overflow: hidden;
     padding: var(--space-3xl) 0;
     position: relative;
-}
-
-/* Dark Mode Journey Adjustments */
-[data-theme='dark'] .journey {
-    background: linear-gradient(135deg, var(--color-bg-dark) 0%, #0f1410 100%);
-    border-block-end: 1px solid var(--card-border);
-    border-block-start: 1px solid var(--card-border);
 }
 
 .journey__content {

--- a/packages/sitepackage/Resources/Private/Assets/Styles/main.entry.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/main.entry.css
@@ -22,22 +22,22 @@
 /* ============================================
    COMPONENTS
    ============================================ */
-@import './components/event/detail.css' layer(component);
-@import './components/event/list.css' layer(component);
-@import './components/about.css' layer(component);
-@import './components/buttons.css' layer(component);
-@import './components/events.css' layer(component);
-@import './components/faq.css' layer(component);
-@import './components/features.css' layer(component);
-@import './components/footer.css' layer(component);
-@import './components/form.css' layer(component);
-@import './components/header.css' layer(component);
-@import './components/hero.css' layer(component);
-@import './components/journey.css' layer(component);
-@import './components/misc.css' layer(component);
-@import './components/navigation.css' layer(component);
-@import './components/quote.css' layer(component);
-@import './components/text.css' layer(component);
+@import './components/event/detail.css' layer(components);
+@import './components/event/list.css' layer(components);
+@import './components/about.css' layer(components);
+@import './components/buttons.css' layer(components);
+@import './components/events.css' layer(components);
+@import './components/faq.css' layer(components);
+@import './components/features.css' layer(components);
+@import './components/footer.css' layer(components);
+@import './components/form.css' layer(components);
+@import './components/header.css' layer(components);
+@import './components/hero.css' layer(components);
+@import './components/journey.css' layer(components);
+@import './components/misc.css' layer(components);
+@import './components/navigation.css' layer(components);
+@import './components/quote.css' layer(components);
+@import './components/text.css' layer(components);
 
 /* ============================================
    UTILITIES (highest priority)


### PR DESCRIPTION
This commit fixes several dark mode styling issues that were introduced
during the CSS file reorganization in commits 6478386 and 026ba93:

- Fix CSS layer naming mismatch (component vs components)
- Replace undefined CSS variables with correct ones:
  - --bg-color--light → --section-bg-alt
  - --font-color → --color-text
  - --color--primary → --color-primary
- Fix footer dark mode using light-dark() instead of data-theme
- Fix hero gradient for dark mode compatibility
- Fix journey section dark mode using light-dark() function

All changes use the modern light-dark() CSS function for better
theme-aware styling instead of separate data-theme selectors where
appropriate.