### PR TITLE
feat: add response cache middleware for TYPO3

### DIFF
--- a/packages/sitepackage/Classes/Middleware/ResponseCacheMiddleware.php
+++ b/packages/sitepackage/Classes/Middleware/ResponseCacheMiddleware.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the mens-circle/sitepackage extension.
+ * Created by Markus Sommer
+ * "Slow your breath, slow your mind — let the right code appear."
+ */
+
+namespace MensCircle\Sitepackage\Middleware;
+
+use MensCircle\Sitepackage\Service\CacheKeyGenerator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\StreamFactory;
+
+/**
+ * PSR-15 Middleware for caching full HTTP responses.
+ *
+ * This middleware:
+ * - Caches only successful GET requests without Extbase parameters
+ * - Skips caching for logged-in frontend users
+ * - Supports ETag-based conditional requests (304 Not Modified)
+ * - Uses TYPO3's cache framework for storage
+ * - Adds debug headers in development mode
+ *
+ * Similar to spatie/laravel-responsecache but tailored for TYPO3.
+ */
+final readonly class ResponseCacheMiddleware implements MiddlewareInterface
+{
+    private const string CACHE_IDENTIFIER = 'response_cache';
+
+    private const int CACHE_LIFETIME = 3600; // 1 hour
+
+    private FrontendInterface $cache;
+
+    public function __construct(
+        private CacheKeyGenerator $cacheKeyGenerator,
+        private Context $context,
+        CacheManager $cacheManager,
+    ) {
+        $this->cache = $cacheManager->getCache(self::CACHE_IDENTIFIER);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // Only cache GET requests
+        if ($request->getMethod() !== 'GET') {
+            return $handler->handle($request);
+        }
+
+        // Skip caching if request should not be cached
+        if (!$this->shouldCacheRequest($request)) {
+            return $handler->handle($request);
+        }
+
+        // Generate cache key
+        $cacheKey = $this->cacheKeyGenerator->generate($request);
+
+        // Check for cached response
+        $cachedData = $this->cache->get($cacheKey);
+
+        if ($cachedData !== false && is_array($cachedData)) {
+            return $this->createCachedResponse($request, $cachedData);
+        }
+
+        // Process request and cache response
+        $response = $handler->handle($request);
+
+        if ($this->shouldCacheResponse($response)) {
+            $this->cacheResponse($cacheKey, $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Determine if the request should be cached.
+     */
+    private function shouldCacheRequest(ServerRequestInterface $request): bool
+    {
+        // Don't cache requests with Extbase parameters (forms, plugins, etc.)
+        $queryParams = $request->getQueryParams();
+        foreach (array_keys($queryParams) as $param) {
+            if (is_string($param) && str_starts_with($param, 'tx_')) {
+                return false;
+            }
+        }
+
+        // Don't cache for logged-in frontend users
+        try {
+            if ($this->context->getPropertyFromAspect('frontend.user', 'isLoggedIn', false)) {
+                return false;
+            }
+        } catch (\Exception) {
+            // If context is not available, don't cache
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the response should be cached.
+     */
+    private function shouldCacheResponse(ResponseInterface $response): bool
+    {
+        // Only cache successful responses
+        if ($response->getStatusCode() !== 200) {
+            return false;
+        }
+
+        // Only cache HTML and JSON responses
+        $contentType = $response->getHeaderLine('Content-Type');
+        if ($contentType === '') {
+            return false;
+        }
+
+        return str_contains($contentType, 'text/html') || str_contains($contentType, 'application/json');
+    }
+
+    /**
+     * Cache the response.
+     */
+    private function cacheResponse(string $cacheKey, ResponseInterface $response): void
+    {
+        $body = (string) $response->getBody();
+        $etag = $this->cacheKeyGenerator->generateETag($body);
+
+        $data = [
+            'body' => $body,
+            'headers' => $response->getHeaders(),
+            'status_code' => $response->getStatusCode(),
+            'etag' => $etag,
+            'cached_at' => time(),
+        ];
+
+        $this->cache->set($cacheKey, $data, [], self::CACHE_LIFETIME);
+    }
+
+    /**
+     * Create a response from cached data.
+     */
+    private function createCachedResponse(ServerRequestInterface $request, array $cachedData): ResponseInterface
+    {
+        $etag = $cachedData['etag'] ?? null;
+
+        // Handle conditional request (If-None-Match)
+        if ($etag !== null && $this->hasMatchingETag($request, $etag)) {
+            return new Response('php://temp', 304, [
+                'ETag' => $etag,
+                'Cache-Control' => 'public, max-age=' . self::CACHE_LIFETIME,
+            ]);
+        }
+
+        // Create full response from cache
+        $headers = $cachedData['headers'] ?? [];
+
+        // Add cache-related headers
+        $headers['ETag'] = [$etag];
+        $headers['Cache-Control'] = ['public, max-age=' . self::CACHE_LIFETIME];
+        $headers['X-Response-Cache'] = ['HIT'];
+        $headers['X-Response-Cache-Age'] = [(string) (time() - ($cachedData['cached_at'] ?? time()))];
+
+        return new Response(
+            body: (new StreamFactory())->createStream($cachedData['body'] ?? ''),
+            status: $cachedData['status_code'] ?? 200,
+            headers: $headers,
+        );
+    }
+
+    /**
+     * Check if the request has a matching ETag.
+     */
+    private function hasMatchingETag(ServerRequestInterface $request, string $etag): bool
+    {
+        $ifNoneMatch = $request->getHeaderLine('If-None-Match');
+
+        if ($ifNoneMatch === '') {
+            return false;
+        }
+
+        // Support multiple ETags separated by comma
+        $requestETags = array_map('trim', explode(',', $ifNoneMatch));
+
+        return in_array($etag, $requestETags, true);
+    }
+}

--- a/packages/sitepackage/Classes/Service/CacheKeyGenerator.php
+++ b/packages/sitepackage/Classes/Service/CacheKeyGenerator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the mens-circle/sitepackage extension.
+ * Created by Markus Sommer
+ * "Slow your breath, slow your mind — let the right code appear."
+ */
+
+namespace MensCircle\Sitepackage\Service;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Generates unique cache keys for HTTP requests.
+ *
+ * Creates deterministic cache keys based on:
+ * - Request URI (path + query)
+ * - Accept headers (for content negotiation)
+ * - Accept-Language header (for i18n)
+ */
+final readonly class CacheKeyGenerator
+{
+    private const string CACHE_KEY_PREFIX = 'response_cache_';
+
+    /**
+     * Generate a unique cache key for the given request.
+     */
+    public function generate(ServerRequestInterface $request): string
+    {
+        $uri = $request->getUri();
+        $path = $uri->getPath();
+        $query = $uri->getQuery();
+
+        // Build cache key components
+        $components = [
+            'uri' => $path . ($query !== '' ? '?' . $query : ''),
+            'accept' => $request->getHeaderLine('Accept'),
+            'accept_language' => $request->getHeaderLine('Accept-Language'),
+        ];
+
+        // Create hash from components
+        $hash = hash('xxh128', serialize($components));
+
+        return self::CACHE_KEY_PREFIX . $hash;
+    }
+
+    /**
+     * Generate an ETag for the given content.
+     */
+    public function generateETag(string $content): string
+    {
+        return '"' . hash('xxh128', $content) . '"';
+    }
+}

--- a/packages/sitepackage/Configuration/RequestMiddlewares.php
+++ b/packages/sitepackage/Configuration/RequestMiddlewares.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 
 use MensCircle\Sitepackage\Middleware\EventApiMiddleware;
+use MensCircle\Sitepackage\Middleware\ResponseCacheMiddleware;
 use MensCircle\Sitepackage\Middleware\SentryTracingMiddleware;
 
 return [
@@ -16,6 +17,11 @@ return [
         'mens-circle/sitepackage/sentry-tracing' => [
             'target' => SentryTracingMiddleware::class,
             'before' => ['typo3/cms-frontend/timetracker'],
+        ],
+        'mens-circle/sitepackage/response-cache' => [
+            'target' => ResponseCacheMiddleware::class,
+            'after' => ['mens-circle/sitepackage/sentry-tracing'],
+            'before' => ['typo3/cms-frontend/page-resolver'],
         ],
         'mens-circle/sitepackage/event' => [
             'target' => EventApiMiddleware::class,

--- a/packages/sitepackage/ext_localconf.php
+++ b/packages/sitepackage/ext_localconf.php
@@ -59,6 +59,17 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
         'loginFootnote' => '© 2023-2024 Build with ❤️ and mindfulness in Bavaria',
     ];
 
+    // Configure response cache
+    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['response_cache'])) {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['response_cache'] = [
+            'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
+            'backend' => \TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class,
+            'options' => [
+                'defaultLifetime' => 3600,
+            ],
+        ];
+    }
+
     ExtensionManagementUtility::addTypoScriptSetup('
         plugin.tx_form {
           settings {


### PR DESCRIPTION
Implement a PSR-15 compliant response cache middleware similar to
spatie/laravel-responsecache, tailored for TYPO3 v14.

Features:
- Caches only successful GET requests (200 responses)
- Excludes requests with Extbase parameters (tx_*) to preserve
  form and plugin functionality
- Skips caching for logged-in frontend users
- Supports ETag-based conditional requests (304 Not Modified)
- Uses TYPO3's cache framework with database backend
- Adds debug headers (X-Response-Cache, X-Response-Cache-Age)

Components:
- CacheKeyGenerator: Generates unique cache keys based on URI,
  Accept headers, and Accept-Language for proper content negotiation
- ResponseCacheMiddleware: Main middleware that handles caching
  logic and ETag validation
- Cache configuration in ext_localconf.php with 1-hour lifetime

The middleware runs after Sentry tracing and before TYPO3's
page resolver for optimal performance monitoring and caching.