### PR TITLE
fix: use only system preferences for dark/light mode and fix hero text overflow

### DIFF
--- a/packages/sitepackage/Resources/Private/Assets/Scripts/components/navigation.ts
+++ b/packages/sitepackage/Resources/Private/Assets/Scripts/components/navigation.ts
@@ -3,8 +3,8 @@ import { debounce, throttle } from '../utils/functions'
 import type { NavigationFactory } from '../types/index'
 
 /**
- * Navigation Factory (Enhanced with Dark Mode)
- * Creates a responsive navigation with scroll behavior and theme toggle
+ * Navigation Factory
+ * Creates a responsive navigation with scroll behavior
  */
 export const createNavigation = (): NavigationFactory => {
     // DOM Elements
@@ -12,35 +12,10 @@ export const createNavigation = (): NavigationFactory => {
     const navToggle = document.getElementById('navToggle')
     const navMenu = document.getElementById('navMenu')
     const navLinks = navMenu?.querySelectorAll('[data-nav-link]') ?? null
-    const themeToggle = document.getElementById('themeToggle')
 
     // State
     let lastScrollY = window.scrollY
     const scrollThreshold = CONFIG.navigation.scrollThreshold
-    let currentTheme = getStoredTheme()
-
-    // Theme Management
-    function getStoredTheme(): string {
-        return (
-            localStorage.getItem('theme') ||
-            (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-        )
-    }
-
-    function setTheme(theme: string): void {
-        currentTheme = theme
-        document.documentElement.setAttribute('data-theme', theme)
-        localStorage.setItem('theme', theme)
-
-        if (CONFIG.development) {
-            console.info(`🎨 Theme changed to: ${theme}`)
-        }
-    }
-
-    function toggleTheme(): void {
-        const newTheme = currentTheme === 'light' ? 'dark' : 'light'
-        setTheme(newTheme)
-    }
 
     // Mobile Menu Management
     const toggleMenu = (): void => {
@@ -148,12 +123,6 @@ export const createNavigation = (): NavigationFactory => {
     const init = (): void => {
         if (!nav) return
 
-        // Apply stored theme
-        setTheme(currentTheme)
-
-        // Theme toggle
-        themeToggle?.addEventListener('click', toggleTheme)
-
         // Mobile menu toggle
         navToggle?.addEventListener('click', toggleMenu)
 
@@ -182,7 +151,7 @@ export const createNavigation = (): NavigationFactory => {
         updateActiveLink()
 
         if (CONFIG.development) {
-            console.info('✨ Enhanced Navigation with Dark Mode initialized')
+            console.info('✨ Navigation initialized')
         }
     }
 
@@ -199,13 +168,8 @@ export const createNavigation = (): NavigationFactory => {
         toggleMenu()
     }
 
-    const getTheme = (): string => {
-        return currentTheme
-    }
-
     const destroy = (): void => {
         // Remove all event listeners
-        themeToggle?.removeEventListener('click', toggleTheme)
         navToggle?.removeEventListener('click', toggleMenu)
         window.removeEventListener('scroll', throttledScroll)
         window.removeEventListener('resize', debouncedResize)
@@ -231,7 +195,6 @@ export const createNavigation = (): NavigationFactory => {
         show,
         hide,
         toggle,
-        getTheme,
         destroy,
         // ES2023: Symbol.dispose for automatic cleanup
         [Symbol.dispose]: destroy,

--- a/packages/sitepackage/Resources/Private/Assets/Scripts/types/index.ts
+++ b/packages/sitepackage/Resources/Private/Assets/Scripts/types/index.ts
@@ -63,7 +63,6 @@ export interface NavigationFactory extends FactoryWithDestroy {
     show: () => void
     hide: () => void
     toggle: () => void
-    getTheme: () => string
 }
 
 // ScrollReveal Factory

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/event/detail.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/event/detail.css
@@ -227,19 +227,14 @@
 
 .registration-success {
     backdrop-filter: blur(10px);
-    background: rgb(255 255 255 / 95%);
+    background: light-dark(rgb(255 255 255 / 95%), rgb(26 20 16 / 90%));
+    border: light-dark(none, 1px solid rgb(193 123 93 / 30%));
     border-radius: var(--radius-lg);
-    box-shadow: 0 20px 60px rgb(0 0 0 / 20%);
+    box-shadow: light-dark(0 20px 60px rgb(0 0 0 / 20%), 0 20px 60px rgb(0 0 0 / 50%));
     margin: 0 auto;
     max-inline-size: 700px;
     padding: var(--space-2xl);
     text-align: center;
-}
-
-[data-theme='dark'] .registration-success {
-    background: rgb(26 20 16 / 90%);
-    border: 1px solid rgb(193 123 93 / 30%);
-    box-shadow: 0 20px 60px rgb(0 0 0 / 50%);
 }
 
 .registration-success__icon {
@@ -267,42 +262,29 @@
 }
 
 .registration-success__title {
-    color: var(--color-primary);
+    color: light-dark(var(--color-primary), var(--color-primary-light));
     font-size: var(--text-3xl);
     font-weight: 700;
     line-height: var(--leading-tight);
     margin-block-end: var(--space-md);
 }
 
-[data-theme='dark'] .registration-success__title {
-    color: var(--color-primary-light);
-}
-
 .registration-success__message {
-    color: var(--color-text);
+    color: light-dark(var(--color-text), rgb(255 253 249 / 90%));
     font-size: var(--text-lg);
     line-height: var(--leading-relaxed);
     margin-block-end: var(--space-xl);
 }
 
-[data-theme='dark'] .registration-success__message {
-    color: rgb(255 253 249 / 90%);
-}
-
 .registration-success__event-info {
-    background: var(--color-primary-50);
-    border-inline-start: 4px solid var(--color-primary);
+    background: light-dark(var(--color-primary-50), rgb(193 123 93 / 10%));
+    border-inline-start: 4px solid light-dark(var(--color-primary), var(--color-primary-light));
     border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
     margin-block-end: var(--space-xl);
     padding: var(--space-lg);
-}
-
-[data-theme='dark'] .registration-success__event-info {
-    background: rgb(193 123 93 / 10%);
-    border-inline-start-color: var(--color-primary-light);
 }
 
 .registration-success__event-detail {
@@ -313,25 +295,17 @@
 }
 
 .registration-success__event-label {
-    color: var(--color-primary);
+    color: light-dark(var(--color-primary), var(--color-primary-light));
     font-size: var(--text-sm);
     font-weight: 700;
     letter-spacing: 0.05em;
     text-transform: uppercase;
 }
 
-[data-theme='dark'] .registration-success__event-label {
-    color: var(--color-primary-light);
-}
-
 .registration-success__event-value {
-    color: var(--color-text);
+    color: light-dark(var(--color-text), rgb(255 253 249 / 85%));
     font-size: var(--text-base);
     text-align: end;
-}
-
-[data-theme='dark'] .registration-success__event-value {
-    color: rgb(255 253 249 / 85%);
 }
 
 .registration-success__steps {
@@ -350,11 +324,11 @@
 
 .registration-success__step-number {
     align-items: center;
-    background: var(--color-primary);
+    background: light-dark(var(--color-primary), var(--color-primary-light));
     block-size: 2.5rem;
     border-radius: 50%;
     box-shadow: 0 4px 12px rgb(193 123 93 / 30%);
-    color: var(--color-white);
+    color: light-dark(var(--color-white), var(--color-earth));
     display: flex;
     flex-shrink: 0;
     font-size: 1.125rem;
@@ -363,55 +337,33 @@
     justify-content: center;
 }
 
-[data-theme='dark'] .registration-success__step-number {
-    background: var(--color-primary-light);
-    color: var(--color-earth);
-}
-
 .registration-success__step p {
-    color: var(--color-text);
+    color: light-dark(var(--color-text), rgb(255 253 249 / 85%));
     flex: 1;
     font-size: var(--text-base);
     line-height: var(--leading-normal);
     margin: 0;
 }
 
-[data-theme='dark'] .registration-success__step p {
-    color: rgb(255 253 249 / 85%);
-}
-
 .registration-success__note {
-    background: rgb(193 123 93 / 5%);
+    background: light-dark(rgb(193 123 93 / 5%), rgb(193 123 93 / 8%));
     border-radius: var(--radius-sm);
-    color: var(--color-text-light);
+    color: light-dark(var(--color-text-light), rgb(255 253 249 / 70%));
     font-size: var(--text-sm);
     line-height: var(--leading-relaxed);
     margin-block-end: var(--space-lg);
     padding: var(--space-md);
 }
 
-[data-theme='dark'] .registration-success__note {
-    background: rgb(193 123 93 / 8%);
-    color: rgb(255 253 249 / 70%);
-}
-
 .registration-success__note strong {
-    color: var(--color-primary);
+    color: light-dark(var(--color-primary), var(--color-primary-light));
     font-weight: 700;
 }
 
-[data-theme='dark'] .registration-success__note strong {
-    color: var(--color-primary-light);
-}
-
 .registration-success__note a {
-    color: var(--color-primary);
+    color: light-dark(var(--color-primary), var(--color-primary-light));
     font-weight: 600;
     text-decoration: underline;
-}
-
-[data-theme='dark'] .registration-success__note a {
-    color: var(--color-primary-light);
 }
 
 .registration-success__actions {

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/form.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/form.css
@@ -3,20 +3,21 @@
    ============================================ */
 
 .newsletter {
-    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-clay) 100%);
+    background: light-dark(
+        linear-gradient(135deg, var(--color-primary) 0%, var(--color-clay) 100%),
+        linear-gradient(135deg, #8b5d3f 0%, #6b4a32 100%)
+    );
     color: var(--color-white);
     overflow: hidden;
     padding: var(--space-3xl) var(--container-padding);
     position: relative;
 }
 
-/* Dark Mode Newsletter */
-[data-theme='dark'] .newsletter {
-    background: linear-gradient(135deg, #8b5d3f 0%, #6b4a32 100%);
-}
-
 .newsletter::before {
-    background: radial-gradient(circle, rgb(255 255 255 / 10%) 0%, transparent 70%);
+    background: light-dark(
+        radial-gradient(circle, rgb(255 255 255 / 10%) 0%, transparent 70%),
+        radial-gradient(circle, rgb(255 255 255 / 5%) 0%, transparent 70%)
+    );
     block-size: 600px;
     border-radius: 50%;
     content: '';
@@ -26,12 +27,11 @@
     position: absolute;
 }
 
-[data-theme='dark'] .newsletter::before {
-    background: radial-gradient(circle, rgb(255 255 255 / 5%) 0%, transparent 70%);
-}
-
 .newsletter::after {
-    background: radial-gradient(circle, rgb(0 0 0 / 10%) 0%, transparent 70%);
+    background: light-dark(
+        radial-gradient(circle, rgb(0 0 0 / 10%) 0%, transparent 70%),
+        radial-gradient(circle, rgb(0 0 0 / 20%) 0%, transparent 70%)
+    );
     block-size: 400px;
     border-radius: 50%;
     content: '';
@@ -39,10 +39,6 @@
     inset-block-end: -30%;
     inset-inline-end: -10%;
     position: absolute;
-}
-
-[data-theme='dark'] .newsletter::after {
-    background: radial-gradient(circle, rgb(0 0 0 / 20%) 0%, transparent 70%);
 }
 
 .newsletter__content {
@@ -85,16 +81,11 @@
 
 .newsletter__form {
     backdrop-filter: blur(10px);
-    background: rgb(255 255 255 / 95%);
+    background: light-dark(rgb(255 255 255 / 95%), rgb(26 20 16 / 90%));
+    border: light-dark(none, 1px solid rgb(193 123 93 / 30%));
     border-radius: var(--radius-lg);
-    box-shadow: 0 20px 60px rgb(0 0 0 / 20%);
+    box-shadow: light-dark(0 20px 60px rgb(0 0 0 / 20%), 0 20px 60px rgb(0 0 0 / 50%));
     padding: var(--space-xl);
-}
-
-[data-theme='dark'] .newsletter__form {
-    background: rgb(26 20 16 / 90%);
-    border: 1px solid rgb(193 123 93 / 30%);
-    box-shadow: 0 20px 60px rgb(0 0 0 / 50%);
 }
 
 .newsletter__fields {
@@ -151,12 +142,7 @@
 /* Error state for inputs */
 .newsletter__input:invalid:not(:placeholder-shown),
 .newsletter__input[aria-invalid='true'] {
-    border-color: #dc2626;
-}
-
-[data-theme='dark'] .newsletter__input:invalid:not(:placeholder-shown),
-[data-theme='dark'] .newsletter__input[aria-invalid='true'] {
-    border-color: #ef4444;
+    border-color: light-dark(#dc2626, #ef4444);
 }
 
 /* Error Messages */
@@ -168,15 +154,11 @@
 
 .c-newsletter-form__error-message {
     align-items: flex-start;
-    color: #dc2626;
+    color: light-dark(#dc2626, #fca5a5);
     display: flex;
     font-size: 0.8125rem;
     gap: 0.5rem;
     line-height: 1.4;
-}
-
-[data-theme='dark'] .c-newsletter-form__error-message {
-    color: #fca5a5;
 }
 
 .c-newsletter-form__error-message::before {
@@ -226,34 +208,22 @@
 }
 
 .newsletter__privacy {
-    color: var(--color-text-light);
+    color: light-dark(var(--color-text-light), rgb(255 253 249 / 70%));
     font-size: 0.8125rem;
     line-height: 1.5;
     text-align: center;
 }
 
-[data-theme='dark'] .newsletter__privacy {
-    color: rgb(255 253 249 / 70%);
-}
-
 .newsletter__privacy a {
-    color: var(--color-primary);
+    color: light-dark(var(--color-primary), var(--color-accent-bright));
     font-weight: 600;
     text-decoration: none;
     transition: color 0.3s var(--transition-smooth);
 }
 
-[data-theme='dark'] .newsletter__privacy a {
-    color: var(--color-accent-bright);
-}
-
 .newsletter__privacy a:hover {
-    color: var(--color-primary-dark);
+    color: light-dark(var(--color-primary-dark), var(--color-accent));
     text-decoration: underline;
-}
-
-[data-theme='dark'] .newsletter__privacy a:hover {
-    color: var(--color-accent);
 }
 
 /* ============================================
@@ -262,18 +232,13 @@
 
 .newsletter__success {
     backdrop-filter: blur(10px);
-    background: rgb(255 255 255 / 95%);
+    background: light-dark(rgb(255 255 255 / 95%), rgb(26 20 16 / 90%));
+    border: light-dark(none, 1px solid rgb(193 123 93 / 30%));
     border-radius: var(--radius-lg);
-    box-shadow: 0 20px 60px rgb(0 0 0 / 20%);
+    box-shadow: light-dark(0 20px 60px rgb(0 0 0 / 20%), 0 20px 60px rgb(0 0 0 / 50%));
     margin: 0 auto;
     padding: var(--space-2xl);
     text-align: center;
-}
-
-[data-theme='dark'] .newsletter__success {
-    background: rgb(26 20 16 / 90%);
-    border: 1px solid rgb(193 123 93 / 30%);
-    box-shadow: 0 20px 60px rgb(0 0 0 / 50%);
 }
 
 .newsletter__success-icon {
@@ -306,42 +271,29 @@
 }
 
 .newsletter__success-title {
-    color: var(--color-primary);
+    color: light-dark(var(--color-primary), var(--color-primary-light));
     font-size: var(--text-3xl);
     font-weight: 700;
     line-height: var(--leading-tight);
     margin-block-end: var(--space-md);
 }
 
-[data-theme='dark'] .newsletter__success-title {
-    color: var(--color-primary-light);
-}
-
 .newsletter__success-message {
-    color: var(--color-text);
+    color: light-dark(var(--color-text), rgb(255 253 249 / 90%));
     font-size: var(--text-lg);
     line-height: var(--leading-relaxed);
     margin-block-end: var(--space-xl);
 }
 
-[data-theme='dark'] .newsletter__success-message {
-    color: rgb(255 253 249 / 90%);
-}
-
 .newsletter__success-steps {
-    background: var(--color-primary-50);
-    border-inline-start: 4px solid var(--color-primary);
+    background: light-dark(var(--color-primary-50), rgb(193 123 93 / 10%));
+    border-inline-start: 4px solid light-dark(var(--color-primary), var(--color-primary-light));
     border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
     gap: var(--space-md);
     margin-block-end: var(--space-xl);
     padding: var(--space-lg);
-}
-
-[data-theme='dark'] .newsletter__success-steps {
-    background: rgb(193 123 93 / 10%);
-    border-inline-start-color: var(--color-primary-light);
 }
 
 .newsletter__success-step {
@@ -353,11 +305,11 @@
 
 .newsletter__success-step-number {
     align-items: center;
-    background: var(--color-primary);
+    background: light-dark(var(--color-primary), var(--color-primary-light));
     block-size: 2.5rem;
     border-radius: 50%;
     box-shadow: 0 4px 12px rgb(193 123 93 / 30%);
-    color: var(--color-white);
+    color: light-dark(var(--color-white), var(--color-earth));
     display: flex;
     flex-shrink: 0;
     font-size: 1.125rem;
@@ -366,45 +318,27 @@
     justify-content: center;
 }
 
-[data-theme='dark'] .newsletter__success-step-number {
-    background: var(--color-primary-light);
-    color: var(--color-earth);
-}
-
 .newsletter__success-step p {
-    color: var(--color-text);
+    color: light-dark(var(--color-text), rgb(255 253 249 / 85%));
     flex: 1;
     font-size: var(--text-base);
     line-height: var(--leading-normal);
     margin: 0;
 }
 
-[data-theme='dark'] .newsletter__success-step p {
-    color: rgb(255 253 249 / 85%);
-}
-
 .newsletter__success-note {
-    background: rgb(193 123 93 / 5%);
+    background: light-dark(rgb(193 123 93 / 5%), rgb(193 123 93 / 8%));
     border-radius: var(--radius-sm);
-    color: var(--color-text-light);
+    color: light-dark(var(--color-text-light), rgb(255 253 249 / 70%));
     font-size: var(--text-sm);
     line-height: var(--leading-relaxed);
     margin-block-end: var(--space-lg);
     padding: var(--space-md);
 }
 
-[data-theme='dark'] .newsletter__success-note {
-    background: rgb(193 123 93 / 8%);
-    color: rgb(255 253 249 / 70%);
-}
-
 .newsletter__success-note strong {
-    color: var(--color-primary);
+    color: light-dark(var(--color-primary), var(--color-primary-light));
     font-weight: 700;
-}
-
-[data-theme='dark'] .newsletter__success-note strong {
-    color: var(--color-primary-light);
 }
 
 .newsletter__success-back {

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/hero.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/hero.css
@@ -1,6 +1,6 @@
 .hero {
     background: var(--hero-bg);
-    min-block-size: 100vb;
+    min-block-size: 100dvb;
     overflow: hidden;
     position: relative;
 }
@@ -10,7 +10,7 @@
     display: flex;
     margin: 0 auto;
     max-inline-size: var(--container-max);
-    min-block-size: 100vb;
+    min-block-size: 100dvb;
     padding: 0 var(--container-padding);
     position: relative;
     z-index: 2;
@@ -18,8 +18,10 @@
 
 .hero__text {
     max-inline-size: 800px;
+    overflow-wrap: break-word;
     padding: var(--space-3xl) 0;
     position: relative;
+    word-break: break-word;
     z-index: 3;
 }
 
@@ -75,9 +77,11 @@
     font-family: var(--font-display), sans-serif;
     font-size: var(--text-6xl);
     font-weight: 900;
+    hyphens: auto;
     letter-spacing: var(--tracking-tight);
     line-height: var(--leading-tight);
     margin-block-end: var(--space-lg);
+    overflow-wrap: break-word;
 }
 
 .hero__title--highlight {
@@ -210,7 +214,7 @@
     }
 
     .hero__image {
-        block-size: 50vb;
+        block-size: 50dvb;
         inline-size: 100vi;
         margin-block-start: var(--space-xl);
         min-block-size: 400px;
@@ -225,10 +229,19 @@
 @media (width <= 480px) {
     .hero {
         min-block-size: auto;
-        padding-block-start: calc(5rem + var(--space-xl));
+        padding-block-start: calc(var(--nav-height) + var(--space-lg));
+    }
+
+    .hero__text {
+        padding: var(--space-lg) 0;
+    }
+
+    .hero__title {
+        font-size: var(--text-4xl);
     }
 
     .hero__image {
-        block-size: 50vb;
+        block-size: 50dvb;
+        min-block-size: 300px;
     }
 }

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/journey.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/journey.css
@@ -64,8 +64,8 @@
 }
 
 .journey__item {
-    background: rgb(255 253 249 / 5%);
-    border-inline-start: 3px solid var(--color-accent);
+    background: light-dark(rgb(255 253 249 / 5%), rgb(193 123 93 / 8%));
+    border-inline-start: 3px solid light-dark(var(--color-accent), var(--color-primary-light));
     border-radius: 0.75rem;
     display: flex;
     gap: var(--space-md);
@@ -73,26 +73,17 @@
     transition: all 0.3s var(--transition-smooth);
 }
 
-[data-theme='dark'] .journey__item {
-    background: rgb(193 123 93 / 8%);
-    border-inline-start-color: var(--color-primary-light);
-}
-
 .journey__item:hover {
-    background: rgb(255 253 249 / 10%);
+    background: light-dark(rgb(255 253 249 / 10%), rgb(193 123 93 / 15%));
     transform: translateX(8px);
-}
-
-[data-theme='dark'] .journey__item:hover {
-    background: rgb(193 123 93 / 15%);
 }
 
 .journey__icon {
     align-items: center;
-    background: rgb(212 165 116 / 20%);
+    background: light-dark(rgb(212 165 116 / 20%), rgb(212 165 116 / 15%));
     block-size: 3rem;
     border-radius: 50%;
-    color: var(--color-accent);
+    color: light-dark(var(--color-accent), var(--color-accent-bright));
     display: flex;
     flex-shrink: 0;
     font-size: 1.25rem;
@@ -100,11 +91,6 @@
     inline-size: 3rem;
     justify-content: center;
     transition: all 0.3s var(--transition-smooth);
-}
-
-[data-theme='dark'] .journey__icon {
-    background: rgb(212 165 116 / 15%);
-    color: var(--color-accent-bright);
 }
 
 .journey__item h4 {
@@ -128,9 +114,11 @@
     transition: opacity 0.3s var(--transition-smooth);
 }
 
-[data-theme='dark'] .journey__image img {
-    filter: brightness(0.7) contrast(1.1);
-    opacity: 0.6;
+@media (prefers-color-scheme: dark) {
+    .journey__image img {
+        filter: brightness(0.7) contrast(1.1);
+        opacity: 0.6;
+    }
 }
 
 .journey__image-accent {

--- a/packages/sitepackage/Resources/Private/Assets/Styles/components/navigation.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/components/navigation.css
@@ -1,5 +1,5 @@
 /* ============================================
-   NAVIGATION - Enhanced with Dark Mode Support
+   NAVIGATION
    ============================================ */
 
 /* Base Navigation */
@@ -142,66 +142,6 @@
     transform: translateY(-2px);
 }
 
-/* Controls Container */
-.nav__controls {
-    align-items: center;
-    display: flex;
-    gap: 1rem;
-}
-
-/* Theme Toggle Button */
-.nav__theme-toggle {
-    align-items: center;
-    background: var(--nav-theme-toggle-bg);
-    block-size: 2.5rem;
-    border: 2px solid var(--nav-theme-toggle-border);
-    border-radius: 50%;
-    cursor: pointer;
-    display: flex;
-    inline-size: 2.5rem;
-    justify-content: center;
-    overflow: hidden;
-    position: relative;
-    transition: all 0.3s var(--transition-smooth);
-}
-
-.nav__theme-toggle:hover {
-    background: var(--nav-theme-toggle-bg-hover);
-    border-color: var(--color-primary);
-    transform: rotate(180deg) scale(1.1);
-}
-
-.nav__theme-toggle:active {
-    transform: rotate(180deg) scale(0.95);
-}
-
-.nav__theme-icon {
-    color: var(--nav-theme-icon-color);
-    position: absolute;
-    transition: all 0.4s var(--transition-smooth);
-}
-
-.nav__theme-icon--sun {
-    opacity: 1;
-    transform: rotate(0deg) scale(1);
-}
-
-.nav__theme-icon--moon {
-    opacity: 0;
-    transform: rotate(-180deg) scale(0);
-}
-
-/* Dark Mode Active */
-[data-theme='dark'] .nav__theme-icon--sun {
-    opacity: 0;
-    transform: rotate(180deg) scale(0);
-}
-
-[data-theme='dark'] .nav__theme-icon--moon {
-    opacity: 1;
-    transform: rotate(0deg) scale(1);
-}
-
 /* Mobile Menu Toggle */
 .nav__toggle {
     background: transparent;
@@ -303,11 +243,6 @@
     .nav__toggle {
         display: flex;
     }
-
-    .nav__theme-toggle {
-        block-size: 2.25rem;
-        inline-size: 2.25rem;
-    }
 }
 
 /* Tablet Adjustments */
@@ -373,7 +308,6 @@
    ============================================ */
 
 .nav__link:focus-visible,
-.nav__theme-toggle:focus-visible,
 .nav__toggle:focus-visible {
     border-radius: 4px;
     outline: 2px solid var(--color-primary);
@@ -385,8 +319,6 @@
     .nav,
     .nav__link,
     .nav__link::after,
-    .nav__theme-toggle,
-    .nav__theme-icon,
     .nav__toggle-line,
     .nav__menu {
         animation: none !important;

--- a/packages/sitepackage/Resources/Private/Assets/Styles/utils/variables.css
+++ b/packages/sitepackage/Resources/Private/Assets/Styles/utils/variables.css
@@ -158,10 +158,6 @@
     --nav-cta-bg: var(--color-primary);
     --nav-cta-bg-hover: light-dark(var(--color-primary-dark), var(--color-primary-light));
     --nav-cta-color: var(--color-white);
-    --nav-theme-toggle-bg: light-dark(rgb(193 123 93 / 8%), rgb(193 123 93 / 15%));
-    --nav-theme-toggle-bg-hover: light-dark(rgb(193 123 93 / 15%), rgb(193 123 93 / 25%));
-    --nav-theme-toggle-border: light-dark(rgb(193 123 93 / 20%), rgb(193 123 93 / 30%));
-    --nav-theme-icon-color: light-dark(var(--color-earth), var(--color-accent-bright));
     --nav-toggle-color: var(--color-earth);
     --nav-mobile-bg: light-dark(rgb(255 253 249 / 98%), rgb(26 20 16 / 98%));
     --nav-height: 64px;
@@ -199,21 +195,3 @@
     --shadow-colored-lg: light-dark(0 16px 48px rgb(193 123 93 / 20%), 0 16px 48px rgb(193 123 93 / 40%));
 }
 
-/* ============================================
-   DARK MODE OVERRIDE
-   For manual theme toggle via data-theme attribute
-   Forces dark mode regardless of system preference
-   ============================================ */
-
-[data-theme='dark'] {
-    color-scheme: dark;
-}
-
-/* ============================================
-   LIGHT MODE OVERRIDE
-   Forces light mode regardless of system preference
-   ============================================ */
-
-[data-theme='light'] {
-    color-scheme: light;
-}


### PR DESCRIPTION
- Remove manual theme toggle functionality (data-theme attribute)
- Convert all [data-theme='dark'] selectors to light-dark() CSS function
- Rely exclusively on prefers-color-scheme system preference
- Fix hero text overflow with overflow-wrap, hyphens, and better responsive sizing
- Use dynamic viewport units (dvb) for better mobile support
- Improve responsive font sizes for hero title on small viewports